### PR TITLE
PB-1943 Sanitize s3 file names

### DIFF
--- a/explorer.js
+++ b/explorer.js
@@ -376,7 +376,7 @@ function ViewController($scope, SharedService) {
 		const href = object2hrefvirt($scope.view.settings.bucket, s3FileKey);
 
 		// ETag is in quotes so we need to remove them
-		const etag = s3File.ETag.split('"').join("");
+		const etag = s3File.ETag.replace(/"/g, "");
 
 		if (s3File.CommonPrefix) {
 			// DEBUG.log("is folder: " + data);
@@ -717,7 +717,7 @@ function ViewController($scope, SharedService) {
 		$scope.view.keys_selected = [];
 
 		$tb.DataTable().rows().data().each((data) => {
-			const etag = data.ETag.split('"').join("")
+			const etag = data.ETag.replace(/"/g, "");
 			const link = document.querySelector(`[data-etag="${etag}"]`);
 			const checkbox = link && link.parentElement && link.parentElement.parentElement
 				? link.parentElement.parentElement.querySelector("input[type='checkbox']")

--- a/explorer.js
+++ b/explorer.js
@@ -98,6 +98,12 @@ function qs(key) {
 	return match && decodeURIComponent(match[1].replace(/\+/g, " "));
 }
 
+function sanitizeString(str) {
+	const tmpElement = document.createElement("div");
+	tmpElement.innerText = str;
+	return tmpElement.innerHTML;
+}
+
 //
 // Shared service that all controllers can use
 //
@@ -358,27 +364,31 @@ function ViewController($scope, SharedService) {
 		});
 	});
 
-	$scope.renderObject = (data, _type, full) => {
-		// DEBUG.log("renderObject:", JSON.stringify(full));
-		const href = object2hrefvirt($scope.view.settings.bucket, data);
-
-		function render(d, href2, text, download) {
-			if (download) {
-				return `<a data-s3="object" data-s3key="${d}" href="${href2}" download="${download}">${text}</a>`;
-			}
-			return `<a data-s3="folder" data-s3key="${d}" href="${href2}">${text}</a>`;
+	function makeS3FileDownloadLink(etag, href, text, download) {
+		if (download) {
+			return `<a data-s3="object" data-etag="${etag}" href="${href}" download="${download}">${sanitizeString(text)}</a>`;
 		}
 
-		if (full.CommonPrefix) {
+		return `<a data-s3="folder" data-etag="${etag}" href="${href}">${sanitizeString(text)}</a>`;
+	}
+
+	$scope.renderObject = (s3FileKey, _type, s3File) => {
+		const href = object2hrefvirt($scope.view.settings.bucket, s3FileKey);
+
+		// ETag is in quotes so we need to remove them
+		const etag = s3File.ETag.split('"').join("");
+
+		if (s3File.CommonPrefix) {
 			// DEBUG.log("is folder: " + data);
 			if ($scope.view.settings.prefix) {
-				return render(data, href, prefix2folder(data));
+
+				return makeS3FileDownloadLink(etag, href, prefix2folder(s3FileKey));
 			}
 
-			return render(data, href, data);
+			return makeS3FileDownloadLink(etag, href, s3FileKey);
 		}
 
-		return render(data, href, fullpath2filename(data), fullpath2filename(data));
+		return makeS3FileDownloadLink(etag, href, fullpath2filename(s3FileKey), fullpath2filename(s3FileKey));
 	};
 
 	$scope.renderFolder = (data, _type, full) => (full.CommonPrefix ? '' : fullpath2pathname(data));
@@ -707,7 +717,8 @@ function ViewController($scope, SharedService) {
 		$scope.view.keys_selected = [];
 
 		$tb.DataTable().rows().data().each((data) => {
-			const link = document.querySelector(`[data-s3Key="${data.Key}"]`);
+			const etag = data.ETag.split('"').join("")
+			const link = document.querySelector(`[data-etag="${etag}"]`);
 			const checkbox = link && link.parentElement && link.parentElement.parentElement
 				? link.parentElement.parentElement.querySelector("input[type='checkbox']")
 				: null;


### PR DESCRIPTION
https://phantombuster.atlassian.net/browse/PB-1943?atlOrigin=eyJpIjoiZGFkMTFkNjlhMDM4NDU2NWE0OTljY2M2NTg0YjhhOWEiLCJwIjoiaiJ9

```
If a filename contains special characters it will also break the “select all” button.

It’s also possible to trigger javascript code by uploading a file named like : --><!-- ---> <img src=xxx:x onerror=javascript:alert(1)> -->

```

I didn't want to add another library to the project so I choose a simple way of sanitizing a string by creating a DOM element and setting the `innerText` property. It might be better to use an external lib but I'm not sure it's worth it, let me know!

# How to test

The easiest way to test this locally is to host the s3 explorer using an http server.
To do so, go to the root of `aws-js-s3-explorer` and create a `serve.py` file:

```python
#!/usr/bin/env python
import http.server

class MyHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
    def end_headers(self):
        self.send_my_headers()
        http.server.SimpleHTTPRequestHandler.end_headers(self)

    def send_my_headers(self):
        self.send_header("Cache-Control", "no-cache, no-store, must-revalidate")
        self.send_header("Pragma", "no-cache")
        self.send_header("Expires", "0")


if __name__ == '__main__':
    http.server.test(HandlerClass=MyHTTPRequestHandler)
```

Run the server using `python serve.py`.

Then, open the frontend's `Agent/index.tsx` file and edit the `openFileBrowser` function so that it targets your local server instead:
```
...
const url = `http://localhost:8000/?settings=${btoa(JSON.stringify(s3BrowserSettings))}`
window.open(url, "_blank")
```

You can now go to any agent's file browser and upload files to test that the behavior is correct. I recommend uploading some files that are named as an XSS payload. You can use this list to see the possible xss payloads: https://github.com/payloadbox/xss-payload-list

Make sure the "select all" feature still works even with filenames containing characters such as `<`, `>`, `"`, `'`, `/` and such.